### PR TITLE
Remove "error" `console.log()` when used port is ignored

### DIFF
--- a/packages/jest-dev-server/src/index.js
+++ b/packages/jest-dev-server/src/index.js
@@ -99,7 +99,6 @@ async function checkIsPortBusy(config) {
   return new Promise((resolve) => {
     const server = createServer()
       .once("error", (err) => {
-        console.log("error");
         if (err.code === "EADDRINUSE") {
           resolve(true);
         } else {
@@ -107,7 +106,6 @@ async function checkIsPortBusy(config) {
         }
       })
       .once("listening", () => {
-        console.log("listening");
         server.once("close", () => resolve(false)).close();
       })
       .listen(config.port);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

When running **jest-dev-server** with `{ usedPortAction: 'ignore' }` "error" text is logged on every test run:

```console
Determining test suites to run...error

Port is already taken. Assuming server is already running.
```

Looks like two unintentional `console.log()` messages were left behind in:

* https://github.com/argos-ci/jest-puppeteer/pull/518

Thanks