### PR TITLE
docs(jest-dev-server): update teardown docs with servers global

### DIFF
--- a/packages/jest-dev-server/README.md
+++ b/packages/jest-dev-server/README.md
@@ -20,7 +20,7 @@ npm install --save-dev jest-dev-server
 
 ## Usage
 
-`jest-dev-server` exports `setup`,`teardown` and `getServers` functions.
+`jest-dev-server` exports `setup` and `teardown` functions.
 
 ```js
 // global-setup.js
@@ -59,16 +59,14 @@ module.exports = async function globalSetup() {
 
 ```js
 // global-setup.js
-const { setup: setupDevServer, getServers } = require("jest-dev-server");
+const { setup: setupDevServer } = require("jest-dev-server");
 
 module.exports = async function globalSetup() {
-  await setupDevServer({
+  // You can get to the servers and do whatever you want
+  globalThis.servers = await setupDevServer({
     command: `node config/start.js --port=3000`,
     launchTimeout: 50000,
     port: 3000,
-  });
-  getServers.then((servers) => {
-    // You can get to the servers and do whatever you want
   });
   // Your global setup
 };
@@ -79,7 +77,7 @@ module.exports = async function globalSetup() {
 const { teardown: teardownDevServer } = require("jest-dev-server");
 
 module.exports = async function globalTeardown() {
-  await teardownDevServer();
+  await teardownDevServer(globalThis.servers);
   // Your global teardown
 };
 ```


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

We've noticed the module-scoped [`const servers = []`](https://github.com/argos-ci/jest-puppeteer/blob/v7.0.1/packages/jest-dev-server/src/index.js#LL43C19-L43C20) was removed in v8.0.0

* https://github.com/alphagov/govuk-frontend/pull/3363#pullrequestreview-1326812806

With this gone, it's no longer possible to run `teardown()` without providing a list of processes

This PR updates the documentation to:

1. Remove references to `getServers()`
2. Update examples to add server processes to `globalThis`

This is nicely inline with the Jest `globalSetup` example too:
https://jestjs.io/docs/configuration#globalsetup-string

Fixes: https://github.com/argos-ci/jest-puppeteer/issues/529