### PR TITLE
Document moved `setup` and `teardown` exports for global hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ For this use case, `jest-environment-puppeteer` exposes two methods: `setup` and
 
 ```js
 // global-setup.js
-const { setup: setupPuppeteer } = require("jest-environment-puppeteer");
+const setupPuppeteer = require("jest-environment-puppeteer/setup");
 
 module.exports = async function globalSetup(globalConfig) {
   await setupPuppeteer(globalConfig);
@@ -283,7 +283,7 @@ module.exports = async function globalSetup(globalConfig) {
 
 ```js
 // global-teardown.js
-const { teardown: teardownPuppeteer } = require("jest-environment-puppeteer");
+const teardownPuppeteer = require("jest-environment-puppeteer/teardown");
 
 module.exports = async function globalTeardown(globalConfig) {
   // Your global teardown

--- a/packages/jest-dev-server/README.md
+++ b/packages/jest-dev-server/README.md
@@ -26,7 +26,7 @@ npm install --save-dev jest-dev-server
 // global-setup.js
 const { setup: setupDevServer } = require("jest-dev-server");
 
-const options = async function globalSetup() {
+module.exports = async function globalSetup() {
   globalThis.servers = await setupDevServer({
     command: `node config/start.js --port=3000`,
     launchTimeout: 50000,
@@ -40,7 +40,7 @@ const options = async function globalSetup() {
 // global-teardown.js
 const { teardown: teardownDevServer } = require("jest-dev-server");
 
-const options = async function globalTeardown() {
+module.exports = async function globalTeardown() {
   await teardownDevServer(globalThis.servers);
   // Your global teardown
 };
@@ -54,7 +54,7 @@ You can specify several servers using an array of configs:
 // global-setup.js
 const { setup: setupDevServer } = require("jest-dev-server");
 
-const options = async function globalSetup() {
+module.exports = async function globalSetup() {
   globalThis.servers = await setupDevServer([
     {
       command: "node server.js",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Fixes documentation for the `setup` and `teardown` global hooks to resolve:

* https://github.com/argos-ci/jest-puppeteer/issues/534

Additionally, the changes in https://github.com/argos-ci/jest-puppeteer/commit/d256469c1de4b36d0218e58fb43aa1482338fd7d now throw:

```console
TypeError: Jest: Got error running globalSetup - /path/to/project/config/jest/browser/open.js, reason: globalSetup file must export a function at /path/to/project/config/jest/browser/open.js
    at /path/to/project/node_modules/@jest/core/build/runGlobalHook.js:105:21
```

So I've switched the docs back to ~`const options = `~ `module.exports = `