### PR TITLE
chore: upgrade wait-on to fix axois security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3864,9 +3864,9 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
     },
     "node_modules/@types/wait-on": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@types/wait-on/-/wait-on-5.3.2.tgz",
-      "integrity": "sha512-7NBSJs/YvbHlaYCJ7wIUF6t7ct3OMt525NmZ+US73pPlkmpxd9ADwfNxrRAmg8nWlcTMqR0PkhW7aYk3FLlvrQ==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@types/wait-on/-/wait-on-5.3.4.tgz",
+      "integrity": "sha512-EBsPjFMrFlMbbUFf9D1Fp+PAB2TwmUn7a3YtHyD9RLuTIk1jDd8SxXVAoez2Ciy+8Jsceo2MYEYZzJ/DvorOKw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -4422,10 +4422,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
-      "dev": true,
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -11236,9 +11235,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.10.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.10.2.tgz",
-      "integrity": "sha512-hcVhjBxRNW/is3nNLdGLIjkgXetkeGc2wyhydhz8KumG23Aerk4HPjU5zaPAMRqXQFc0xNqXTC7+zQjxr0GlKA==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.11.0.tgz",
+      "integrity": "sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
@@ -16861,30 +16860,21 @@
       }
     },
     "node_modules/wait-on": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.0.1.tgz",
-      "integrity": "sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
       "dependencies": {
-        "axios": "^0.27.2",
-        "joi": "^17.7.0",
+        "axios": "^1.6.1",
+        "joi": "^17.11.0",
         "lodash": "^4.17.21",
-        "minimist": "^1.2.7",
-        "rxjs": "^7.8.0"
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
       },
       "bin": {
         "wait-on": "bin/wait-on"
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/wait-on/node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
       }
     },
     "node_modules/walker": {
@@ -17257,12 +17247,12 @@
         "prompts": "^2.4.2",
         "spawnd": "^9.0.1",
         "tree-kill": "^1.2.2",
-        "wait-on": "^7.0.1"
+        "wait-on": "^7.2.0"
       },
       "devDependencies": {
         "@types/cwd": "^0.10.0",
         "@types/prompts": "^2.4.5",
-        "@types/wait-on": "^5.3.2",
+        "@types/wait-on": "^5.3.4",
         "rollup": "^3.29.4",
         "rollup-plugin-dts": "^6.0.2",
         "rollup-plugin-swc3": "^0.10.1"
@@ -20160,9 +20150,9 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
     },
     "@types/wait-on": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@types/wait-on/-/wait-on-5.3.2.tgz",
-      "integrity": "sha512-7NBSJs/YvbHlaYCJ7wIUF6t7ct3OMt525NmZ+US73pPlkmpxd9ADwfNxrRAmg8nWlcTMqR0PkhW7aYk3FLlvrQ==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@types/wait-on/-/wait-on-5.3.4.tgz",
+      "integrity": "sha512-EBsPjFMrFlMbbUFf9D1Fp+PAB2TwmUn7a3YtHyD9RLuTIk1jDd8SxXVAoez2Ciy+8Jsceo2MYEYZzJ/DvorOKw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -20541,10 +20531,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
-      "dev": true,
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -25160,7 +25149,7 @@
       "requires": {
         "@types/cwd": "^0.10.0",
         "@types/prompts": "^2.4.5",
-        "@types/wait-on": "^5.3.2",
+        "@types/wait-on": "^5.3.4",
         "chalk": "^4.1.2",
         "cwd": "^0.10.0",
         "find-process": "^1.4.7",
@@ -25170,7 +25159,7 @@
         "rollup-plugin-swc3": "^0.10.1",
         "spawnd": "^9.0.1",
         "tree-kill": "^1.2.2",
-        "wait-on": "^7.0.1"
+        "wait-on": "^7.2.0"
       }
     },
     "jest-diff": {
@@ -25786,9 +25775,9 @@
       }
     },
     "joi": {
-      "version": "17.10.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.10.2.tgz",
-      "integrity": "sha512-hcVhjBxRNW/is3nNLdGLIjkgXetkeGc2wyhydhz8KumG23Aerk4HPjU5zaPAMRqXQFc0xNqXTC7+zQjxr0GlKA==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.11.0.tgz",
+      "integrity": "sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==",
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
@@ -30055,26 +30044,15 @@
       "dev": true
     },
     "wait-on": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.0.1.tgz",
-      "integrity": "sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
       "requires": {
-        "axios": "^0.27.2",
-        "joi": "^17.7.0",
+        "axios": "^1.6.1",
+        "joi": "^17.11.0",
         "lodash": "^4.17.21",
-        "minimist": "^1.2.7",
-        "rxjs": "^7.8.0"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.27.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-          "requires": {
-            "follow-redirects": "^1.14.9",
-            "form-data": "^4.0.0"
-          }
-        }
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
       }
     },
     "walker": {

--- a/packages/jest-dev-server/package.json
+++ b/packages/jest-dev-server/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@types/cwd": "^0.10.0",
     "@types/prompts": "^2.4.5",
-    "@types/wait-on": "^5.3.2",
+    "@types/wait-on": "^5.3.4",
     "rollup": "^3.29.4",
     "rollup-plugin-dts": "^6.0.2",
     "rollup-plugin-swc3": "^0.10.1"
@@ -51,6 +51,6 @@
     "prompts": "^2.4.2",
     "spawnd": "^9.0.1",
     "tree-kill": "^1.2.2",
-    "wait-on": "^7.0.1"
+    "wait-on": "^7.2.0"
   }
 }


### PR DESCRIPTION
Fixes axios security vulnerability CVE-2023-45857.

## Summary
Upgrade wait-on to [v7.2.0](https://github.com/jeffbski/wait-on/releases/tag/v7.2.0) to trigger axios upgrade from 0.27.2 to 1.6.1.

## Test plan

