### PR TITLE
fix: correct homepage link which was missing full dir name

### DIFF
--- a/packages/jest-environment-puppeteer/package.json
+++ b/packages/jest-environment-puppeteer/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/argos-ci/jest-puppeteer.git",
     "directory": "packages/jest-environment-puppeteer"
   },
-  "homepage": "https://github.com/argos-ci/jest-puppeteer/tree/main/packages/jest-environme#readme",
+  "homepage": "https://github.com/argos-ci/jest-puppeteer/tree/main/packages/jest-environment-puppeteer#readme",
   "bugs": {
     "url": "https://github.com/argos-ci/jest-puppeteer/issues"
   },


### PR DESCRIPTION
## Summary

The homepage link in the package results in a 404 error as the directory name had been cut off.

## Test plan

–