### PR TITLE
Add Puppeteer v22 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 18, "latest"]
+        node-version: [18, 20, "latest"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ After installing Argos, learn how to [review visual changes](https://argos-ci.co
 module.exports = {
   launch: {
     dumpio: true,
-    headless: process.env.HEADLESS !== "false" ? "new" : false,
+    headless: process.env.HEADLESS !== "false",
   },
   server: {
     command: "node server.js",
@@ -213,7 +213,7 @@ Default config values:
 module.exports = {
   launch: {
     dumpio: true,
-    headless: process.env.HEADLESS !== "false" ? "new" : false,
+    headless: process.env.HEADLESS !== "false",
     product: "chrome",
   },
   browserContext: "default",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "jest": "^29.7.0",
         "lerna": "^7.4.2",
         "prettier": "^3.1.0",
-        "puppeteer": "^21.5.2",
+        "puppeteer": "^22.0.0",
         "typescript": "^5.3.2"
       },
       "engines": {
@@ -3175,9 +3175,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.8.0.tgz",
-      "integrity": "sha512-TkRHIV6k2D8OlUe8RtG+5jgOF/H98Myx0M6AOafC8DdNVOFiBSFa5cpRDtpm8LXOa9sVwe0+e6Q3FC56X/DZfg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.0.0.tgz",
+      "integrity": "sha512-3PS82/5+tnpEaUWonjAFFvlf35QHF15xqyGd34GBa5oP5EPVfFXRsbSxIGYf1M+vZlqBZ3oxT1kRg9OYhtt8ng==",
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -3191,7 +3191,7 @@
         "browsers": "lib/cjs/main-cli.js"
       },
       "engines": {
-        "node": ">=16.3.0"
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -4704,9 +4704,9 @@
       ]
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
-      "integrity": "sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.4.tgz",
+      "integrity": "sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -5255,12 +5255,12 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.4.33",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.33.tgz",
-      "integrity": "sha512-IxoFM5WGQOIAd95qrSXzJUv4eXIrh+RvU3rwwqIiwYuvfE7U/Llj4fejbsJnjJMUYCuGtVQsY2gv7oGl4aTNSQ==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.8.tgz",
+      "integrity": "sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==",
       "dependencies": {
         "mitt": "3.0.1",
-        "urlpattern-polyfill": "9.0.0"
+        "urlpattern-polyfill": "10.0.0"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
@@ -7077,9 +7077,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1203626",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1203626.tgz",
-      "integrity": "sha512-nEzHZteIUZfGCZtTiS1fRpC8UZmsfD1SiyPvaUNvS13dvKf666OAm8YTi0+Ca3n1nLEyu49Cy4+dPWpaHFJk9g=="
+      "version": "0.0.1232444",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
+      "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg=="
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -7263,7 +7263,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -15100,33 +15099,61 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "21.5.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.5.2.tgz",
-      "integrity": "sha512-BaAGJOq8Fl6/cck6obmwaNLksuY0Bg/lIahCLhJPGXBFUD2mCffypa4A592MaWnDcye7eaHmSK9yot0pxctY8A==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.0.0.tgz",
+      "integrity": "sha512-zYVnjwJngnSB4dbkWp7DHFSIc3nqHvZzrdHyo9+ugV1nq1Lm8obOMcmCFaGfR3PJs0EmYNz+/skBeO45yvASCQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "1.8.0",
-        "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.5.2"
+        "@puppeteer/browsers": "2.0.0",
+        "cosmiconfig": "9.0.0",
+        "puppeteer-core": "22.0.0"
+      },
+      "bin": {
+        "puppeteer": "lib/esm/puppeteer/node/cli.js"
       },
       "engines": {
-        "node": ">=16.13.2"
+        "node": ">=18"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.5.2",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.5.2.tgz",
-      "integrity": "sha512-v4T0cWnujSKs+iEfmb8ccd7u4/x8oblEyKqplqKnJ582Kw8PewYAWvkH4qUWhitN3O2q9RF7dzkvjyK5HbzjLA==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.0.0.tgz",
+      "integrity": "sha512-S3s91rLde0A86PWVeNY82h+P0fdS7CTiNWAicCVH/bIspRP4nS2PnO5j+VTFqCah0ZJizGzpVPAmxVYbLxTc9w==",
       "dependencies": {
-        "@puppeteer/browsers": "1.8.0",
-        "chromium-bidi": "0.4.33",
+        "@puppeteer/browsers": "2.0.0",
+        "chromium-bidi": "0.5.8",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1203626",
-        "ws": "8.14.2"
+        "devtools-protocol": "0.0.1232444",
+        "ws": "8.16.0"
       },
       "engines": {
-        "node": ">=16.13.2"
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer/node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/pure-rand": {
@@ -16359,9 +16386,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.15.5",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.5.tgz",
-      "integrity": "sha512-9thPGMkKC2GctCzyCUjME3yR03x2xNo0GPKGkRw2UMYN+gqWa9uqpyNWhmsNCutU5zHmkUum0LsCRQTXUgUCAg==",
+      "version": "2.15.7",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.7.tgz",
+      "integrity": "sha512-NPEKS5+yjyo597eafGbKW5ujh7Sm6lDLHZQd/lRSz6S0VarpADBJItqfB4PnwpS+472oob1GX5cCY9vzfJpHUA==",
       "dependencies": {
         "fast-fifo": "^1.1.0",
         "queue-tick": "^1.0.1"
@@ -16598,9 +16625,9 @@
       }
     },
     "node_modules/tar-fs/node_modules/tar-stream": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
-      "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
       "dependencies": {
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
@@ -17135,9 +17162,9 @@
       }
     },
     "node_modules/urlpattern-polyfill": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
-      "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -17461,9 +17488,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -17590,7 +17617,7 @@
     "packages/expect-puppeteer": {
       "version": "9.0.2",
       "devDependencies": {
-        "puppeteer": "^21.5.2",
+        "puppeteer": "^22.0.0",
         "rollup": "^4.5.0",
         "rollup-plugin-dts": "^6.1.0",
         "rollup-plugin-swc3": "^0.10.4"
@@ -20005,9 +20032,9 @@
       "optional": true
     },
     "@puppeteer/browsers": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.8.0.tgz",
-      "integrity": "sha512-TkRHIV6k2D8OlUe8RtG+5jgOF/H98Myx0M6AOafC8DdNVOFiBSFa5cpRDtpm8LXOa9sVwe0+e6Q3FC56X/DZfg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.0.0.tgz",
+      "integrity": "sha512-3PS82/5+tnpEaUWonjAFFvlf35QHF15xqyGd34GBa5oP5EPVfFXRsbSxIGYf1M+vZlqBZ3oxT1kRg9OYhtt8ng==",
       "requires": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -21073,9 +21100,9 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "basic-ftp": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
-      "integrity": "sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.4.tgz",
+      "integrity": "sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA=="
     },
     "before-after-hook": {
       "version": "2.2.3",
@@ -21462,12 +21489,12 @@
       "dev": true
     },
     "chromium-bidi": {
-      "version": "0.4.33",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.33.tgz",
-      "integrity": "sha512-IxoFM5WGQOIAd95qrSXzJUv4eXIrh+RvU3rwwqIiwYuvfE7U/Llj4fejbsJnjJMUYCuGtVQsY2gv7oGl4aTNSQ==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.8.tgz",
+      "integrity": "sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==",
       "requires": {
         "mitt": "3.0.1",
-        "urlpattern-polyfill": "9.0.0"
+        "urlpattern-polyfill": "10.0.0"
       }
     },
     "ci-info": {
@@ -22842,9 +22869,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1203626",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1203626.tgz",
-      "integrity": "sha512-nEzHZteIUZfGCZtTiS1fRpC8UZmsfD1SiyPvaUNvS13dvKf666OAm8YTi0+Ca3n1nLEyu49Cy4+dPWpaHFJk9g=="
+      "version": "0.0.1232444",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
+      "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg=="
     },
     "diff-sequences": {
       "version": "29.6.3",
@@ -22987,8 +23014,7 @@
     "env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
     },
     "envinfo": {
       "version": "7.8.1",
@@ -23361,7 +23387,7 @@
     "expect-puppeteer": {
       "version": "file:packages/expect-puppeteer",
       "requires": {
-        "puppeteer": "^21.5.2",
+        "puppeteer": "^22.0.0",
         "rollup": "^4.5.0",
         "rollup-plugin-dts": "^6.1.0",
         "rollup-plugin-swc3": "^0.10.4"
@@ -29073,26 +29099,39 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "21.5.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.5.2.tgz",
-      "integrity": "sha512-BaAGJOq8Fl6/cck6obmwaNLksuY0Bg/lIahCLhJPGXBFUD2mCffypa4A592MaWnDcye7eaHmSK9yot0pxctY8A==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.0.0.tgz",
+      "integrity": "sha512-zYVnjwJngnSB4dbkWp7DHFSIc3nqHvZzrdHyo9+ugV1nq1Lm8obOMcmCFaGfR3PJs0EmYNz+/skBeO45yvASCQ==",
       "requires": {
-        "@puppeteer/browsers": "1.8.0",
-        "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.5.2"
+        "@puppeteer/browsers": "2.0.0",
+        "cosmiconfig": "9.0.0",
+        "puppeteer-core": "22.0.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+          "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+          "requires": {
+            "env-paths": "^2.2.1",
+            "import-fresh": "^3.3.0",
+            "js-yaml": "^4.1.0",
+            "parse-json": "^5.2.0"
+          }
+        }
       }
     },
     "puppeteer-core": {
-      "version": "21.5.2",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.5.2.tgz",
-      "integrity": "sha512-v4T0cWnujSKs+iEfmb8ccd7u4/x8oblEyKqplqKnJ582Kw8PewYAWvkH4qUWhitN3O2q9RF7dzkvjyK5HbzjLA==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.0.0.tgz",
+      "integrity": "sha512-S3s91rLde0A86PWVeNY82h+P0fdS7CTiNWAicCVH/bIspRP4nS2PnO5j+VTFqCah0ZJizGzpVPAmxVYbLxTc9w==",
       "requires": {
-        "@puppeteer/browsers": "1.8.0",
-        "chromium-bidi": "0.4.33",
+        "@puppeteer/browsers": "2.0.0",
+        "chromium-bidi": "0.5.8",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1203626",
-        "ws": "8.14.2"
+        "devtools-protocol": "0.0.1232444",
+        "ws": "8.16.0"
       }
     },
     "pure-rand": {
@@ -30018,9 +30057,9 @@
       "dev": true
     },
     "streamx": {
-      "version": "2.15.5",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.5.tgz",
-      "integrity": "sha512-9thPGMkKC2GctCzyCUjME3yR03x2xNo0GPKGkRw2UMYN+gqWa9uqpyNWhmsNCutU5zHmkUum0LsCRQTXUgUCAg==",
+      "version": "2.15.7",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.7.tgz",
+      "integrity": "sha512-NPEKS5+yjyo597eafGbKW5ujh7Sm6lDLHZQd/lRSz6S0VarpADBJItqfB4PnwpS+472oob1GX5cCY9vzfJpHUA==",
       "requires": {
         "fast-fifo": "^1.1.0",
         "queue-tick": "^1.0.1"
@@ -30214,9 +30253,9 @@
       },
       "dependencies": {
         "tar-stream": {
-          "version": "3.1.6",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
-          "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
+          "version": "3.1.7",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+          "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
           "requires": {
             "b4a": "^1.6.4",
             "fast-fifo": "^1.2.0",
@@ -30592,9 +30631,9 @@
       "dev": true
     },
     "urlpattern-polyfill": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
-      "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg=="
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -30856,9 +30895,9 @@
       }
     },
     "ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
       "requires": {}
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jest": "^29.7.0",
     "lerna": "^7.4.2",
     "prettier": "^3.1.0",
-    "puppeteer": "^21.5.2",
+    "puppeteer": "^22.0.0",
     "typescript": "^5.3.2"
   },
   "name": "jest-puppeteer",

--- a/packages/expect-puppeteer/package.json
+++ b/packages/expect-puppeteer/package.json
@@ -44,7 +44,7 @@
     "build": "rollup -c"
   },
   "devDependencies": {
-    "puppeteer": "^21.5.2",
+    "puppeteer": "^22.0.0",
     "rollup": "^4.5.0",
     "rollup-plugin-dts": "^6.1.0",
     "rollup-plugin-swc3": "^0.10.4"

--- a/packages/jest-environment-puppeteer/README.md
+++ b/packages/jest-environment-puppeteer/README.md
@@ -161,7 +161,7 @@ interface JestPuppeteerConfig {
 module.exports = {
   launch: {
     dumpio: true,
-    headless: process.env.HEADLESS !== "false" ? "new" : false,
+    headless: process.env.HEADLESS !== "false",
   },
   server: {
     command: "node server.js",

--- a/packages/jest-environment-puppeteer/src/env.ts
+++ b/packages/jest-environment-puppeteer/src/env.ts
@@ -100,7 +100,12 @@ const createContext = async (global: StrictGlobal) => {
       global.context = browser.defaultBrowserContext();
       break;
     case "incognito":
-      global.context = await browser.createIncognitoBrowserContext();
+      global.context =
+        "createBrowserContext" in browser
+          ? // API for Puppeteer v22+
+            await browser.createBrowserContext()
+          : // @ts-expect-error // API for Puppeteer <= v21
+            await browser.createIncognitoBrowserContext();
       break;
     default:
       throw new Error(

--- a/server/public/shadow.html
+++ b/server/public/shadow.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <host-element>
-      <template shadowroot="open">
+      <template shadowrootmode="open">
         <header>This is home!</header>
         <slot></slot>
       </template>
@@ -14,7 +14,7 @@
     </host-element>
     <button id="dialog-btn" onclick="window.confirm('Bouh!')">
       <host-element-2>
-        <template shadowroot="open">Open dialog</template>
+        <template shadowrootmode="open">Open dialog</template>
       </host-element-2>
     </button>
   </body>


### PR DESCRIPTION
## Summary

From the [`puppeteer@22` release](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-core-v22.0.0) we have two main breaking changes + docs:

1. Replace Node.js v16 with v20 in GitHub Actions
2. Document that `headless: 'new'` is now `headless: true`
3. Switch to ~`browser.createIncognitoBrowserContext()`~ `browser.createBrowserContext()`

## Test plan

I've added feature detection for `"createBrowserContext" in browser` to maintain support for Puppeteer <= v21
