### PR TITLE
Tolerate missing isIncognito method in Puppeteer v23

### DIFF
--- a/packages/jest-environment-puppeteer/src/env.ts
+++ b/packages/jest-environment-puppeteer/src/env.ts
@@ -116,7 +116,7 @@ const createContext = async (global: StrictGlobal) => {
 
 const closeContext = async (global: StrictGlobal) => {
   if (!global.context) return;
-  if (global.context.isIncognito()) {
+  if (global.context.isIncognito?.()) {
     await global.context.close();
   }
   global.context = undefined;


### PR DESCRIPTION
Fixes #586

## Summary

Upgrading to Puppeteer v23 breaks tests since the isIncognito method has been removed. See https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-core-v23.0.0
https://github.com/puppeteer/puppeteer/pull/12830

## Test plan

Make change in an environment that uses Puppeteer v23. Tests no longer fail.